### PR TITLE
Add HTTPipe.Conn.to_curl/1

### DIFF
--- a/lib/httpipe/conn.ex
+++ b/lib/httpipe/conn.ex
@@ -690,4 +690,15 @@ defmodule HTTPipe.Conn do
 
     conn
   end
+
+
+  @doc """
+  Converts the Conn struct's request into a valid curl string that
+  can be called from the command-line.
+  """
+  @spec to_curl(t) :: String.t
+  def to_curl(conn) do
+    conn.request
+    |> Request.to_curl()
+  end
 end

--- a/lib/httpipe/curl_helpers.ex
+++ b/lib/httpipe/curl_helpers.ex
@@ -26,8 +26,10 @@ defmodule HTTPipe.CurlHelpers do
 
   @spec convert_full_url(Request.url, Request.params) :: String.t
   def convert_full_url(base_url, params) do
-    {:ok, full_url} = Request.prepare_url(base_url, params)
-    full_url
+    case Request.prepare_url(base_url, params) do
+      {:ok, full_url} -> full_url
+      {:error, _} -> ""
+    end
   end
 
   @spec convert_method(Request.method) :: String.t

--- a/lib/httpipe/curl_helpers.ex
+++ b/lib/httpipe/curl_helpers.ex
@@ -1,0 +1,69 @@
+defmodule HTTPipe.CurlHelpers do
+  @moduledoc """
+  Helper module for formatting the `HTTPipe.Request` struct.
+
+  This module has helpers to format a valid curl string that can then be
+  executed from a command-line context.
+  """
+
+  alias HTTPipe.Request
+
+  @doc """
+  Converts a Request struct into a curl string that can
+  be executed normally from the command-line.
+  """
+  @spec convert_request_to_curl(Request.t) :: String.t
+  def convert_request_to_curl(request) do
+    full_url = convert_full_url(request.url, request.params)
+    method = convert_method(request.method)
+    headers = convert_headers(request.headers)
+    body = convert_body(request.body)
+
+    ["curl", "#{method}", "#{full_url}", "#{headers}", "#{body}"]
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join(" ")
+  end
+
+  @spec convert_full_url(Request.url, Request.params) :: String.t
+  def convert_full_url(base_url, params) do
+    {:ok, full_url} = Request.prepare_url(base_url, params)
+    full_url
+  end
+
+  @spec convert_method(Request.method) :: String.t
+  def convert_method(method) do
+    curl_method = method |> Atom.to_string() |> String.upcase()
+    "-X #{curl_method}"
+  end
+
+  @spec convert_headers(Request.headers) :: String.t
+  def convert_headers(headers) do
+    headers
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.reduce([], fn({k, v}, acc) ->
+         [convert_header(k, v) | acc]
+       end)
+    |> Enum.join(" ")
+  end
+
+  @spec convert_header(String.t, String.t) :: String.t
+  def convert_header(k, v) do
+    "-H \"#{k}: #{v}\""
+  end
+
+  @spec convert_body(Request.body) :: String.t
+  def convert_body(nil), do: ""
+  def convert_body({:file, file_path}) do
+    "-d \"@#{file_path}\""
+  end
+  def convert_body({:form, keyword_list}) do
+    keyword_list
+    |> Enum.reduce([], fn(kv, acc) ->
+      ["-F \"#{URI.encode_query([kv])}\"" | acc]
+    end)
+    |> Enum.join(" ")
+  end
+  def convert_body(body) when is_binary(body) do
+    "-d \"#{body}\""
+  end
+end

--- a/lib/httpipe/inspection_helpers.ex
+++ b/lib/httpipe/inspection_helpers.ex
@@ -77,6 +77,7 @@ defmodule HTTPipe.InspectionHelpers do
     full_url = inspect_full_url(request.url, request.params, opts)
     params = inspect_params(request.params, opts)
     body = inspect_body(request.body, opts)
+    curl_string = inspect_curl_string(request, opts)
 
     concat [
       format_section_head("Request"),
@@ -86,7 +87,8 @@ defmodule HTTPipe.InspectionHelpers do
       full_url,
       headers,
       params,
-      body
+      body,
+      curl_string
     ]
   end
 
@@ -209,6 +211,14 @@ defmodule HTTPipe.InspectionHelpers do
            line(existing_doc, inspect_header(k, v))
        end)
     |> format_nested_with_header("Headers")
+  end
+
+  @spec inspect_curl_string(Request.t, Inspect.Opts.t) :: Inspect.Algebra.t
+  def inspect_curl_string(request, opts) do
+    request
+    |> Request.to_curl()
+    |> to_doc(opts)
+    |> format_nested_with_header("Curl String")
   end
 
   @spec inspect_status_code(Response.status_code, Inspect.Opts.t) :: Inspect.Algebra.t

--- a/lib/httpipe/request.ex
+++ b/lib/httpipe/request.ex
@@ -8,7 +8,7 @@ defmodule HTTPipe.Request do
   structs and update internal `Request` structs.
   """
 
-  alias HTTPipe.InspectionHelpers
+  alias HTTPipe.{CurlHelpers, InspectionHelpers}
   alias __MODULE__.{NilURLError}
 
   @typedoc """
@@ -34,7 +34,7 @@ defmodule HTTPipe.Request do
   """
   @type http_version :: String.t
 
-  @typdoc ~S"""
+  @typedoc ~S"""
   Specifies a resource to access
 
   The URL should include the scheme, domain, and request path.
@@ -541,5 +541,14 @@ defmodule HTTPipe.Request do
     |> IO.puts()
 
     req
+  end
+
+  @doc """
+  Converts the Request struct into a valid curl string that
+  can be called from the command-line.
+  """
+  @spec to_curl(t) :: String.t
+  def to_curl(request) do
+    CurlHelpers.convert_request_to_curl(request)
   end
 end

--- a/test/httpipe/curl_helpers_test.exs
+++ b/test/httpipe/curl_helpers_test.exs
@@ -1,0 +1,79 @@
+defmodule HTTPipe.CurlHelpersTest do
+  use ExUnit.Case
+
+  alias HTTPipe.Request
+
+  test "Can encode URL" do
+    request =
+      %Request{}
+      |> Request.put_url("http://api.local/v1")
+
+    curl_string = request |> Request.to_curl()
+    assert curl_string == "curl -X GET http://api.local/v1"
+  end
+
+  test "Can encode HTTP method" do
+    request =
+      %Request{}
+      |> Request.put_url("http://api.local/v1")
+      |> Request.put_method(:post)
+
+    curl_string = request |> Request.to_curl()
+    assert curl_string == "curl -X POST http://api.local/v1"
+  end
+
+  test "Can encode headers" do
+    request =
+      %Request{}
+      |> Request.put_url("http://api.local/v1")
+      |> Request.put_header("Content-Type", "application/json")
+      |> Request.put_header("Accept-Encoding", "gzip")
+
+    curl_string = request |> Request.to_curl()
+    assert curl_string == "curl -X GET http://api.local/v1 -H \"content-type: application/json\" -H \"accept-encoding: gzip\""
+  end
+
+  test "Can encode params into URL" do
+    request =
+      %Request{}
+      |> Request.put_url("http://api.local/v1")
+      |> Request.put_param(:q, "httpipe elixir")
+
+    curl_string = request |> Request.to_curl()
+    assert curl_string == "curl -X GET http://api.local/v1?q=httpipe+elixir"
+  end
+
+  test "Can encode body" do
+    request =
+      %Request{}
+      |> Request.put_url("http://api.local/v1")
+      |> Request.put_body("{}")
+
+    curl_string = request |> Request.to_curl()
+    assert curl_string == "curl -X GET http://api.local/v1 -d \"{}\""
+  end
+
+  test "Can encode form-based body" do
+    req_body = {:form, [q: "elixir strings", limit: 10]}
+    request =
+      %Request{}
+      |> Request.put_url("http://api.local/v1")
+      |> Request.put_method(:post)
+      |> Request.put_body(req_body)
+
+    curl_string = request |> Request.to_curl()
+    assert curl_string == "curl -X POST http://api.local/v1 -F \"limit=10\" -F \"q=elixir+strings\""
+  end
+
+  test "Can encode file-based body" do
+    req_body = {:file, "/tmp/testfile"}
+    request =
+      %Request{}
+      |> Request.put_url("http://api.local/v1")
+      |> Request.put_method(:post)
+      |> Request.put_body(req_body)
+
+    curl_string = request |> Request.to_curl()
+    assert curl_string == "curl -X POST http://api.local/v1 -d \"@/tmp/testfile\""
+  end
+end


### PR DESCRIPTION
🎉 hey! I talked about this before, and finally had some time to come up with a quick POC.

This adds a new module called `HTTPipe.CurlHelpers` which converts a `%HTTPipe.Request{}` into a curl string that can then be executed into the command-line.

- `HTTPipe.Conn.to_curl(request)`
- `HTTPipe.Request.to_curl(request)`
- `HTTPipe.CurlHelpers.convert_request_to_curl(request)`

---

Not sure if this belongs here or not, so totally up to your discretion. This should cover the basics. (headers/params/body/form). (HTTPipe doesn't support multipart yet 😉 )

I also think there's a better way w/ using [OptionParser.to_argv/2](https://hexdocs.pm/elixir/OptionParser.html#to_argv/2) here.

![image](https://cloud.githubusercontent.com/assets/2051361/23286598/b8446cd0-f9ed-11e6-94f0-1456aa9df899.png)

Unfortunately, I'm not sure what to do with the string escaping for the curl command. That makes it a bit harder to just copy/paste into your terminal.
